### PR TITLE
Cites that PeekingIterator was based on guava code

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,9 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+This product contains a modified part of Guava, distributed by Google:
+
+  * License: Apache License v2.0
+  * Homepage: https://github.com/google/guava
+


### PR DESCRIPTION
We are required to update the LICENSE file if we have modified code.
`zipkin2.dependencies.mysql.PeekingIterator` closely resembles a class
in guava: `com.google.common.collect.AbstractIterator`